### PR TITLE
fix sdl_ttf submodule ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = https://github.com/grimfang4/sdl-gpu.git
 [submodule "SDL_ttf"]
 	path = external/SDL_ttf
-	url = https://github.com/flowkey/SDL_ttf-mirror.git
+	url = git@github.com:flowkey/SDL_ttf-mirror.git


### PR DESCRIPTION
https://github.com/mozeal/ seems to be offline. I pushed the version of my local submodule to our flowkey orga, because I havent found any other version that includes the latest commits of 2017 we have in our..