### PR TITLE
ignore changes in SDL2 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,7 @@
 	path = external/SDL2
 	url = git@github.com:spurious/SDL-mirror.git
 	branch = release-2.0.5
+	ignore = dirty
 [submodule "sdl-gpu"]
 	path = external/sdl-gpu
 	url = git@github.com:grimfang4/sdl-gpu.git


### PR DESCRIPTION
This finally prevents dirty version control when working with xcode.
I think its ok to ignore any of the changes there, because [spurious/SDL2](https://github.com/spurious/SDL-mirror/pull/9) is just a mirror of the official SDL repo and its not possible to propose code changes via git prs.


### current behavior
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	Xcode/SDL/SDL.xcodeproj/xcuserdata/
```