### PR TITLE
removed func onNativeTouch to avoid conflict with swift 

### DIFF
--- a/SDL2/src/custom/core/SDL_android.c
+++ b/SDL2/src/custom/core/SDL_android.c
@@ -213,16 +213,6 @@ JNIEXPORT void JNICALL Java_org_libsdl_app_SDLActivity_onNativeKeyboardFocusLost
     SDL_StopTextInput();
 }
 
-
-/* Touch */
-JNIEXPORT void JNICALL Java_org_libsdl_app_SDLActivity_onNativeTouch(
-                                    JNIEnv* env, jclass jcls,
-                                    jint touch_device_id_in, jint pointer_finger_id_in,
-                                    jint action, jfloat x, jfloat y, jfloat p)
-{
-    Android_OnTouch(touch_device_id_in, pointer_finger_id_in, action, x, y, p);
-}
-
 /* Mouse */
 JNIEXPORT void JNICALL Java_org_libsdl_app_SDLActivity_onNativeMouse(
                                     JNIEnv* env, jclass jcls,


### PR DESCRIPTION
We are in the process of sidestepping SDL with our touch implementation (it's meant to go straight from Kotlin code to Swift). In order for that to work, this implementation needs to be removed, and a Swift implementation added (in a PR to UIKit, will be linked here when ready).

DEPENDENCY WARNING: If this is merged without merging the other PR, touch will be broken on Android.